### PR TITLE
feat: added NextFetchEvent support

### DIFF
--- a/package/src/chain.ts
+++ b/package/src/chain.ts
@@ -1,11 +1,11 @@
-import { type NextRequest } from "next/server";
+import type { NextRequest, NextFetchEvent } from "next/server";
 import { collectData } from "./lib/collect-data";
 import { ChainItem } from "./lib/types";
 import { formatResponse } from "./lib/format-response";
 export { FinalNextResponse } from "./lib/final-next-response";
 
-export const chain = (middlewares: ChainItem[]) => async (req: NextRequest) => {
-    const summary = await collectData(req, middlewares);
+export const chain = (middlewares: ChainItem[]) => async (req: NextRequest, event: NextFetchEvent) => {
+    const summary = await collectData(req, event, middlewares);
     const next = formatResponse(summary);
 
     return next;

--- a/package/src/lib/collect-data.ts
+++ b/package/src/lib/collect-data.ts
@@ -1,9 +1,9 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse, type NextRequest, type NextFetchEvent } from "next/server";
 import { ChainItem, Middleware, type ChainNextResponse, type Summary } from "./types";
 import { FinalSymbol } from "./final-next-response";
 import { INTERNAL_HEADERS } from "./constants";
 
-export const collectData = async (req: NextRequest, chainItems: ChainItem[]) => {
+export const collectData = async (req: NextRequest, event: NextFetchEvent, chainItems: ChainItem[]) => {
     const summary: Summary = {
         type: "none",
         destination: req.nextUrl,
@@ -28,7 +28,7 @@ export const collectData = async (req: NextRequest, chainItems: ChainItem[]) => 
         } else {
             middleware = chainItem;
         }
-        const middlewareNext = await middleware(Object.assign(req, { summary: Object.freeze({ ...summary }) }));
+        const middlewareNext = await middleware(Object.assign(req, { summary: Object.freeze({ ...summary }) }), event);
 
         if (!middlewareNext) continue;
 

--- a/package/src/lib/types.ts
+++ b/package/src/lib/types.ts
@@ -1,6 +1,6 @@
 import { type ResponseCookie } from "next/dist/compiled/@edge-runtime/cookies";
 import { type NextURL } from "next/dist/server/web/next-url";
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse, type NextRequest, type NextFetchEvent } from "next/server";
 import { FinalNextResponse, FinalSymbol } from "./final-next-response";
 
 export type NextType = "rewrite" | "redirect" | "json" | "none" | undefined;
@@ -23,6 +23,6 @@ export type ChainNextResponse = FinalNextResponse | (NextResponse & { [FinalSymb
 
 export type MiddlewareResult = ChainNextResponse | Response | void | undefined | null | Promise<MiddlewareResult>;
 
-export type Middleware = (req: ChainNextRequest) => MiddlewareResult;
+export type Middleware = (req: ChainNextRequest, event: NextFetchEvent) => MiddlewareResult;
 
 export type ChainItem = Middleware | [Middleware, { include?: RegExp; exclude?: RegExp }?];


### PR DESCRIPTION
Added the ability to use [NextFetchEvent](https://nextjs.org/docs/app/building-your-application/routing/middleware#waituntil-and-nextfetchevent) in chain middlewares.